### PR TITLE
Scale celery to 13, API to 6

### DIFF
--- a/manifests/base/api-deployment.yaml
+++ b/manifests/base/api-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name:  api
   namespace: notification-canada-ca
 spec:
-  replicas: 4
+  replicas: 6
   selector:
     matchLabels:
       app: api 

--- a/manifests/base/celery-deployment.yaml
+++ b/manifests/base/celery-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name:  celery
   namespace: notification-canada-ca
 spec:
-  replicas: 11
+  replicas: 13
   revisionHistoryLimit: 5
   selector:
     matchLabels:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Scale celery to 13, API pods to 6

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [ ] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [x] I have made #team-sre team aware I am pushing changes
- [x] I know how to get kubectl credentials in case it catches on fire