### PR TITLE
Update admin image - calendar component

### DIFF
--- a/manifests/overlays/eks/kustomization.yaml
+++ b/manifests/overlays/eks/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 
 images:
 - name: admin
-  newName: gcr.io/cdssnc/notify/admin:7ddcb76
+  newName: gcr.io/cdssnc/notify/admin:e72dd49
 - name: api
   newName: gcr.io/cdssnc/notify/api:b3434ef
 - name: document-download-api


### PR DESCRIPTION
Note: Hoping to push tomorrow if possible (March 31)

## What are you changing?
- [ x ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
> Give details ex. Security patching, content update, more API pods etc
Adding Send now / Send later, calendar component updates, and associated work from: https://github.com/cds-snc/notification-admin/pull/417

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ x ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ x ] I made sure that both API and Admin changes are present in Notify
- [ x ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [x] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [ ] I have made #team-sre team aware I am pushing changes
- [ ] I know how to get kubectl credentials in case it catches on fire