### PR TITLE
Fix research bug

### DIFF
--- a/manifests/overlays/eks/kustomization.yaml
+++ b/manifests/overlays/eks/kustomization.yaml
@@ -28,7 +28,7 @@ images:
 - name: admin
   newName: gcr.io/cdssnc/notify/admin:6db02b4
 - name: api
-  newName: gcr.io/cdssnc/notify/api:d7abaa7
+  newName: gcr.io/cdssnc/notify/api:10b9313
 - name: document-download-api
   newName: gcr.io/cdssnc/notify/document-download-api:latest
 - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Fixes a bug where test API keys using SNS SMS sender were throwing errors because of a missing callback see: https://github.com/cds-snc/notification-api/pull/868

## If you are releasing a new version of notify, what components are you updating
- [x] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [x] I made sure that both API and Admin changes are present in Notify
- [x] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [x] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [ ] I have made #team-sre team aware I am pushing changes
- [ ] I know how to get kubectl credentials in case it catches on fire