### PR TITLE
Enable New Relic Distributed Tracing

### DIFF
--- a/manifests/base/admin-deployment.yaml
+++ b/manifests/base/admin-deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_APP_NAME
               value: 'notification-admin-production'
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: 'true'
             - name: NOTIFY_ENVIRONMENT
               value: '$(ENVIRONMENT)'
             - name: SQLALCHEMY_DATABASE_URI

--- a/manifests/base/api-deployment.yaml
+++ b/manifests/base/api-deployment.yaml
@@ -147,6 +147,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_APP_NAME
               value: 'notification-api-production'
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: 'true'
             - name: NOTIFY_EMAIL_DOMAIN
               value: '$(BASE_DOMAIN)'
             - name: NOTIFY_ENVIRONMENT

--- a/manifests/base/celery-beat-deployment.yaml
+++ b/manifests/base/celery-beat-deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_APP_NAME
               value: 'notification-celery-beat-production'
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: 'true'
             - name: NOTIFY_EMAIL_DOMAIN
               value: '$(BASE_DOMAIN)'
             - name: NOTIFY_ENVIRONMENT

--- a/manifests/base/celery-deployment.yaml
+++ b/manifests/base/celery-deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_APP_NAME
               value: 'notification-celery-production'
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: 'true'
             - name: NOTIFY_EMAIL_DOMAIN
               value: '$(BASE_DOMAIN)'
             - name: NOTIFY_ENVIRONMENT


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Add an environment variable to enable New Relic's distributed tracing functionality.
Enabling this will create a link from an admin request to an API request (and/or to a celery request)
Allowing us to track from start to finish the requests as they move from node to node

https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [ ] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [ ] I have made #team-sre team aware I am pushing changes
- [ ] I know how to get kubectl credentials in case it catches on fire