### PR TITLE
Adding the env variables to the API for real

### DIFF
--- a/manifests/base/api-deployment.yaml
+++ b/manifests/base/api-deployment.yaml
@@ -133,6 +133,8 @@ spec:
               value: '$(AWS_SES_ACCESS_KEY)'
             - name: AWS_SES_SECRET_KEY
               value: '$(AWS_SES_SECRET_KEY)'
+            - name: BULK_SEND_TEST_SERVICE_ID
+              value: '$(BULK_SEND_TEST_SERVICE_ID)'
             - name: DANGEROUS_SALT
               value: '$(DANGEROUS_SALT)'
             - name: DOCUMENT_DOWNLOAD_API_HOST
@@ -143,6 +145,10 @@ spec:
               value: '$(FRESH_DESK_API_URL)'
             - name: FRESH_DESK_API_KEY
               value: '$(FRESH_DESK_API_KEY)'
+            - name: HC_EN_SERVICE_ID
+              value: '$(HC_EN_SERVICE_ID)'
+            - name: HC_FR_SERVICE_ID
+              value: '$(HC_FR_SERVICE_ID)'
             - name: MLWR_HOST
               value: '$(MLWR_HOST)'
             - name: MLWR_USER


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Adding the env variables to the other place I forgot about in the api…

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [ ] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [x] I have made #team-sre team aware I am pushing changes
- [x] I know how to get kubectl credentials in case it catches on fire