### PR TITLE
Increase CPU and memory of cloudwatch-agent

### DIFF
--- a/manifests/overlays/eks/cwagent-statsd-deployment.yaml
+++ b/manifests/overlays/eks/cwagent-statsd-deployment.yaml
@@ -19,12 +19,12 @@ spec:
           image: amazon/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
-            limits:
-              cpu:  200m
-              memory: 100Mi
             requests:
-              cpu: 200m
-              memory: 100Mi
+              cpu: "500m"
+              memory: "700Mi"
+            limits:
+              cpu:  "1200m"
+              memory: "900Mi"
           # Pleaes don't change the mountPath
           volumeMounts:
             - name: cwagentconfig


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
This pod seem to have a low amount of memory and CPU, causing bad performance for API pods. I'm increasing CPU and memory to see if it has a positive.

Please advise for more appropriate values if you have something in mind.

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76
- [ ] I have made the #team-sre team aware that I am pushing changes

## Checklist if making changes to Kubernetes:
- [ ] I have made #team-sre team aware I am pushing changes
- [ ] I know how to get kubectl credentials in case it catches on fire