### PR TITLE
New Relic: fix env variable expansion

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -42,7 +42,7 @@ jobs:
              -d \
             '{
               "deployment": {
-                "revision": "$GITHUB_SHA"
+                "revision": "'$GITHUB_SHA'"
               }
             }'
           done


### PR DESCRIPTION
The env variable was not expanded because of single quotes/double quotes

```bash
export GITHUB_SHA='test'
echo '"revision": "'$GITHUB_SHA'"'
# Outputs: "revision": "test"
```