### PR TITLE
Document download API: fix FRONTEND_HOSTNAME

### DIFF
--- a/manifests/base/document-download-api-deployment.yaml
+++ b/manifests/base/document-download-api-deployment.yaml
@@ -32,8 +32,6 @@ spec:
             - name: DOCUMENTS_BUCKET
               value: '$(DOCUMENTS_BUCKET)'
             - name: FRONTEND_HOSTNAME
-              value: '$(BASE_DOMAIN)'
-            - name: FRONTEND_HOSTNAME
               value: 'document.$(BASE_DOMAIN)'
             - name: HTTP_SCHEME
               value: 'https'


### PR DESCRIPTION
The environment variable was set twice in the configuration file.

In prod it's set to `notification.alpha.canada.ca` but it should be `document.notification.alpha.canada.ca`