### PR TITLE
Update admin and API probes

### DIFF
--- a/manifests/base/admin-deployment.yaml
+++ b/manifests/base/admin-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: admin 
+    app: admin
   name:  admin
   namespace: notification-canada-ca
 spec:
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 5
   selector:
     matchLabels:
-      app: admin 
+      app: admin
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -33,7 +33,7 @@ spec:
       containers:
         - image: admin
           imagePullPolicy: Always
-          name: admin 
+          name: admin
           env:
             - name: ADMIN_BASE_URL
               value: https://$(BASE_DOMAIN)
@@ -91,15 +91,23 @@ spec:
           ports:
             - containerPort: 6012
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /_status
               port: 6012
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /_status
               port: 6012
-            initialDelaySeconds: 3
+            initialDelaySeconds: 30
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/manifests/base/api-deployment.yaml
+++ b/manifests/base/api-deployment.yaml
@@ -2,14 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: api 
+    app: api
   name:  api
   namespace: notification-canada-ca
 spec:
   replicas: 6
   selector:
     matchLabels:
-      app: api 
+      app: api
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -105,7 +105,7 @@ spec:
       containers:
         - image: api
           imagePullPolicy: Always
-          name: api 
+          name: api
           env:
             - name: ADMIN_BASE_URL
               value: https://$(BASE_DOMAIN)
@@ -185,7 +185,7 @@ spec:
               value: '$(TWILIO_AUTH_TOKEN)'
             - name: TWILIO_FROM_NUMBER
               value: '$(TWILIO_FROM_NUMBER)'
-          resources: 
+          resources:
             requests:
               cpu: "500m"
               memory: "700Mi"
@@ -196,16 +196,22 @@ spec:
             - containerPort: 6011
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status
               port: 6011
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
           livenessProbe:
             httpGet:
-              path: /
+              path: /_status
               port: 6011
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Updating probes to make sure that we don't use pods that are not ready to serve traffic yet. Avoiding slow responses/pod restarts when deploying.

Already did this change on the new staging yesterday, this PR is to reflect this change in production. Example for [the admin deployment](https://github.com/cds-snc/notification-manifests/blob/main/base/admin-deployment.yaml).

Tested the new k8s probes yesterday by running 10 times `kubectl rollout restart deployment admin` and `kubectl rollout restart deployment api` while curl-ing every 500ms the homepage and did not notice slow responses or a 500 error once.

I'd love to test these new probes in production now to avoid changing probes at the same time as the AWS move.