### PR TITLE
[AUTO-PR] Automatically generated new release 2020-11-24T15:43:44.963Z

### DIFF
--- a/manifests/overlays/eks/kustomization.yaml
+++ b/manifests/overlays/eks/kustomization.yaml
@@ -22,9 +22,9 @@ resources:
   - resource-reader.yaml
 images:
   - name: admin
-    newName: gcr.io/cdssnc/notify/admin:33f5819
+    newName: gcr.io/cdssnc/notify/admin:9758e75
   - name: api
-    newName: gcr.io/cdssnc/notify/api:823c3f0
+    newName: gcr.io/cdssnc/notify/api:8a1de76
   - name: document-download-api
     newName: gcr.io/cdssnc/notify/document-download-api:latest
   - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
ADMIN: 

 - [fix a few CSS bugs (#827)](https://github.com/cds-snc/notification-admin/commit/9758e75ca6f04c2d759566126da0d3b704bd73e0) by Bethany Dunfield
- [Remove hardcoded alpha domain (#825)](https://github.com/cds-snc/notification-admin/commit/3be13a9ac6a3122600151a7e8386b2100019fe68) by Antoine Augusti
- [Update logo and assets domain (#823)](https://github.com/cds-snc/notification-admin/commit/af6e3805703464f7446979f936db14b8ec5a627e) by Antoine Augusti
- [Bump utils to 43.2.0 (#824)](https://github.com/cds-snc/notification-admin/commit/d66155517007e4680219cc3676734020e0162684) by Antoine Augusti
- [More css component tailwind work (#822)](https://github.com/cds-snc/notification-admin/commit/67ec33d230430014961673c514722b03e7eb99c5) by Bethany Dunfield 

 API: 

 - [Remove hardcoded domain from branding request (#1182)](https://github.com/cds-snc/notification-api/commit/8a1de76bd92ac20c08a2e1d953f2c8fba84d5c26) by Antoine Augusti
- [Bump utils to 43.2.0 (#1180)](https://github.com/cds-snc/notification-api/commit/be0b4ddc0c9cbaf7daf557a0a8ae9647b1aa7e7a) by Antoine Augusti
- [fix: The celery dependency should be in the docker-compose workers (#1179)](https://github.com/cds-snc/notification-api/commit/d9dc67f978b58790a90e8069e83c2682bccbc178) by Jimmy Royer

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
